### PR TITLE
Add lost pkgconfig item in widgets.pro.

### DIFF
--- a/widgets/widgets.pro
+++ b/widgets/widgets.pro
@@ -2,7 +2,7 @@ TEMPLATE = lib
 TARGET = DeepinWidgets
 QT += qml quick gui x11extras opengl widgets
 CONFIG += qt plugin c++11 link_pkgconfig
-PKGCONFIG += xcomposite xcb-damage
+PKGCONFIG += xcomposite xcb-damage x11
 
 
 HEADERS += \


### PR DESCRIPTION
Please add this pkgconfig item in widgets.pro, the building could be failed without this item in some distributions.